### PR TITLE
Test #28: Added unit tests for Visualizer

### DIFF
--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,10 +1,6 @@
 import pytest
 import os
-import sys
 import pygame
-
-# Had to add 'src' to path manually because python couldn't find the modules from the tests folder
-sys.path.append(os.path.join(os.path.dirname(__file__), '../src'))
 
 # Found this online to make Pygame run without a monitor (Headless), otherwise CI crashes without a video card
 os.environ["SDL_VIDEODRIVER"] = "dummy"


### PR DESCRIPTION
## Changes
- Added `test_visualizer.py` to cover UI logic.
- Fixed the import paths so Pytest can find the `src` folder correctly.
- Set up a "dummy" video driver (headless mode) so the tests don't crash when running on CI without a monitor.
- Tested the Slider math to make sure it handles min/max clamping and middle clicks.
- Verified that the Visualizer starts up, loads colors properly, and toggles the pause state.

Ran `pytest tests/test_visualizer.py` locally and all **4 tests passed**.

## Related Issue
Closes #28